### PR TITLE
fix : rename routes by Restful API guideline

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -15,7 +15,7 @@ const docTemplate = `{
     "host": "{{.Host}}",
     "basePath": "{{.BasePath}}",
     "paths": {
-        "/event": {
+        "/events": {
             "get": {
                 "description": "Retrieves a list of all events with pagination",
                 "consumes": [
@@ -107,7 +107,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/event/user": {
+        "/events/users": {
             "get": {
                 "security": [
                     {
@@ -141,7 +141,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/event/{event_id}": {
+        "/events/{event_id}": {
             "delete": {
                 "security": [
                     {
@@ -191,7 +191,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/event/{id}": {
+        "/events/{id}": {
             "get": {
                 "description": "Retrieves an event using its unique ID",
                 "consumes": [
@@ -367,7 +367,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/user/login/{user_id}": {
+        "/users/login/{user_id}": {
             "get": {
                 "description": "Simulates a login process for a user by generating fake access and refresh tokens",
                 "consumes": [
@@ -405,7 +405,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/user/logout": {
+        "/users/logout": {
             "post": {
                 "security": [
                     {
@@ -454,7 +454,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/user/profile": {
+        "/users/profile": {
             "get": {
                 "security": [
                     {
@@ -497,7 +497,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/user/refresh_token": {
+        "/users/refresh_token": {
             "post": {
                 "description": "Refreshes the access and refresh tokens for a user",
                 "consumes": [
@@ -549,7 +549,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/user/register": {
+        "/users/register": {
             "post": {
                 "description": "Register a fake user for testing purposes",
                 "consumes": [
@@ -595,7 +595,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/user/{user_id}": {
+        "/users/{user_id}": {
             "get": {
                 "description": "Retrieves a user's information by their ID",
                 "consumes": [

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -4,7 +4,7 @@
         "contact": {}
     },
     "paths": {
-        "/event": {
+        "/events": {
             "get": {
                 "description": "Retrieves a list of all events with pagination",
                 "consumes": [
@@ -96,7 +96,7 @@
                 }
             }
         },
-        "/event/user": {
+        "/events/users": {
             "get": {
                 "security": [
                     {
@@ -130,7 +130,7 @@
                 }
             }
         },
-        "/event/{event_id}": {
+        "/events/{event_id}": {
             "delete": {
                 "security": [
                     {
@@ -180,7 +180,7 @@
                 }
             }
         },
-        "/event/{id}": {
+        "/events/{id}": {
             "get": {
                 "description": "Retrieves an event using its unique ID",
                 "consumes": [
@@ -356,7 +356,7 @@
                 }
             }
         },
-        "/user/login/{user_id}": {
+        "/users/login/{user_id}": {
             "get": {
                 "description": "Simulates a login process for a user by generating fake access and refresh tokens",
                 "consumes": [
@@ -394,7 +394,7 @@
                 }
             }
         },
-        "/user/logout": {
+        "/users/logout": {
             "post": {
                 "security": [
                     {
@@ -443,7 +443,7 @@
                 }
             }
         },
-        "/user/profile": {
+        "/users/profile": {
             "get": {
                 "security": [
                     {
@@ -486,7 +486,7 @@
                 }
             }
         },
-        "/user/refresh_token": {
+        "/users/refresh_token": {
             "post": {
                 "description": "Refreshes the access and refresh tokens for a user",
                 "consumes": [
@@ -538,7 +538,7 @@
                 }
             }
         },
-        "/user/register": {
+        "/users/register": {
             "post": {
                 "description": "Register a fake user for testing purposes",
                 "consumes": [
@@ -584,7 +584,7 @@
                 }
             }
         },
-        "/user/{user_id}": {
+        "/users/{user_id}": {
             "get": {
                 "description": "Retrieves a user's information by their ID",
                 "consumes": [

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -134,7 +134,7 @@ definitions:
 info:
   contact: {}
 paths:
-  /event:
+  /events:
     get:
       consumes:
       - application/json
@@ -193,7 +193,7 @@ paths:
       summary: Subscribe to an event
       tags:
       - Event
-  /event/{event_id}:
+  /events/{event_id}:
     delete:
       consumes:
       - application/json
@@ -225,7 +225,7 @@ paths:
       summary: Delete event
       tags:
       - Event
-  /event/{id}:
+  /events/{id}:
     get:
       consumes:
       - application/json
@@ -286,7 +286,7 @@ paths:
       summary: Update an event
       tags:
       - Event
-  /event/user:
+  /events/users:
     get:
       consumes:
       - application/json
@@ -362,7 +362,7 @@ paths:
       summary: Handle LINE OAuth callback
       tags:
       - OAuth
-  /user/{user_id}:
+  /users/{user_id}:
     get:
       consumes:
       - application/json
@@ -387,7 +387,7 @@ paths:
       summary: Get user by ID
       tags:
       - User
-  /user/login/{user_id}:
+  /users/login/{user_id}:
     get:
       consumes:
       - application/json
@@ -413,7 +413,7 @@ paths:
       summary: Fake Login
       tags:
       - User
-  /user/logout:
+  /users/logout:
     post:
       consumes:
       - application/json
@@ -444,7 +444,7 @@ paths:
       summary: User logout
       tags:
       - User
-  /user/profile:
+  /users/profile:
     get:
       consumes:
       - application/json
@@ -471,7 +471,7 @@ paths:
       summary: Profile
       tags:
       - User
-  /user/refresh_token:
+  /users/refresh_token:
     post:
       consumes:
       - application/json
@@ -505,7 +505,7 @@ paths:
       summary: Refresh User Token
       tags:
       - Authentication
-  /user/register:
+  /users/register:
     post:
       consumes:
       - application/json

--- a/pkg/controller/event_controller.go
+++ b/pkg/controller/event_controller.go
@@ -24,7 +24,7 @@ func NewEventController(eventService model.EventService) *EventController {
 // @Param limit query int false "Number of items per page for pagination"
 // @Success 200 {object} model.EventListResponse "List of events"
 // @Failure 500 {object} model.Response "Internal Server Error"
-// @Router /event [get]
+// @Router /events [get]
 func (ctrl *EventController) GetAllEvent(c *gin.Context) {
 	page, limit := RetrievePagination(c)
 	events, err := ctrl.eventService.FindAll(c, page, limit)
@@ -48,7 +48,7 @@ func (ctrl *EventController) GetAllEvent(c *gin.Context) {
 // @Param id path string true "Event ID"
 // @Success 200 {object} model.EventResponse "Event successfully retrieved"
 // @Failure 500 {object} model.Response "Internal Server Error"
-// @Router /event/{id} [get]
+// @Router /events/{id} [get]
 func (ctrl *EventController) GetEventByID(c *gin.Context) {
 	id := c.Param("id")
 	userID := c.GetString("user_id")
@@ -80,7 +80,7 @@ func (ctrl *EventController) GetEventByID(c *gin.Context) {
 // @Security ApiKeyAuth // include this line if the endpoint is protected by an API key or other security mechanism
 // @Success 200 {object} model.EventListResponse "List of events associated with the user"
 // @Failure 500 {object} model.Response "Internal Server Error"
-// @Router /event/user [get] // adjust the path and HTTP method according to your routing
+// @Router /events/users [get] // adjust the path and HTTP method according to your routing
 func (ctrl *EventController) GetUserEvent(c *gin.Context) {
 	userID := c.GetString("user_id")
 	events, err := ctrl.eventService.FindByUserID(c, userID)
@@ -106,7 +106,7 @@ func (ctrl *EventController) GetUserEvent(c *gin.Context) {
 // @Success 200 {object} model.EventResponse "Successfully subscribed to the event"
 // @Failure 400 {object} model.Response "Bad Request - Invalid input"
 // @Failure 500 {object} model.Response "Internal Server Error"
-// @Router /event [post]
+// @Router /events [post]
 func (ctrl *EventController) SubscribeEvent(c *gin.Context) {
 	userID := c.GetString("user_id")
 	var request model.CreateEventRequest
@@ -148,7 +148,7 @@ func (ctrl *EventController) SubscribeEvent(c *gin.Context) {
 // @Success 200 {object} model.EventResponse "Event successfully updated"
 // @Failure 400 {object} model.Response "Bad Request - Invalid input"
 // @Failure 500 {object} model.Response "Internal Server Error"
-// @Router /event/{id} [put]
+// @Router /events/{id} [put]
 func (ctrl *EventController) UpdateEvent(c *gin.Context) {
 	id := c.Param("id")
 	userID := c.GetString("user_id")
@@ -197,7 +197,7 @@ func (ctrl *EventController) UpdateEvent(c *gin.Context) {
 // @Param event_id path string true "Event ID"
 // @Success 200 {object} model.Response "Event successfully deleted"
 // @Failure 500 {object} model.Response "Internal Server Error"
-// @Router /event/{event_id} [delete]
+// @Router /events/{event_id} [delete]
 func (ctrl *EventController) DeleteEvent(c *gin.Context) {
 	userID := c.GetString("user_id")
 	eventID := c.Param("event_id")

--- a/pkg/controller/user_controller.go
+++ b/pkg/controller/user_controller.go
@@ -33,7 +33,7 @@ func NewUserController(userSvc model.UserService, env *bootstrap.Env) *UserContr
 // @Param user_id path string true "User ID"
 // @Success 200 {object} model.UserResponse "Profile successfully retrieved"
 // @Failure 500 {object} model.Response "Internal Server Error"
-// @Router /user/profile [get]
+// @Router /users/profile [get]
 func (ctrl *UserController) Profile(c *gin.Context) {
 	userID, _ := c.Get("user_id")
 	profile, err := ctrl.userSvc.GetUserByID(c, userID.(string))
@@ -57,7 +57,7 @@ func (ctrl *UserController) Profile(c *gin.Context) {
 // @Param user_id path string true "User ID"
 // @Success 200 {object} model.UserResponse "User successfully retrieved"
 // @Failure 500 {object} model.Response "Internal Server Error"
-// @Router /user/{user_id} [get]
+// @Router /users/{user_id} [get]
 func (ctrl *UserController) GetUserByID(c *gin.Context) {
 	userID := c.Param("user_id")
 	user, err := ctrl.userSvc.GetUserByID(c, userID)
@@ -84,7 +84,7 @@ func (ctrl *UserController) GetUserByID(c *gin.Context) {
 // @Failure 400 {object} model.Response "Bad Request - Invalid request format"
 // @Failure 401 {object} model.Response "Unauthorized - Invalid or expired refresh token"
 // @Failure 500 {object} model.Response "Internal Server Error - Error generating tokens"
-// @Router /user/refresh_token [post]
+// @Router /users/refresh_token [post]
 func (ctrl *UserController) RefreshToken(c *gin.Context) {
 	var request model.RefreshTokenRequest
 
@@ -164,7 +164,7 @@ func (ctrl *UserController) GetUsers(c *gin.Context) {
 // @Success 200 {object} model.Response "Logout successful"
 // @Failure 401 {object} model.Response "Unauthorized: Invalid token format"
 // @Failure 500 {object} model.Response "Internal Server Error"
-// @Router /user/logout [post]
+// @Router /users/logout [post]
 func (ctrl *UserController) Logout(c *gin.Context) {
 	// TODO: need to discuss where to read the token from (header or body or cookie)
 	authHeader := c.GetHeader("Authorization")
@@ -197,7 +197,7 @@ func (ctrl *UserController) Logout(c *gin.Context) {
 // @Param user_id path string true "User ID"
 // @Success 200 {object} model.TokenResponse "Login successful, tokens generated"
 // @Failure 500 {object} model.Response "Internal Server Error"
-// @Router /user/login/{user_id} [get]
+// @Router /users/login/{user_id} [get]
 func (ctrl *UserController) FakeLogin(c *gin.Context) {
 	userID := c.Param("user_id")
 
@@ -241,7 +241,7 @@ func (ctrl *UserController) FakeLogin(c *gin.Context) {
 // @Success 200 {object} model.Response "Fake register successful"
 // @Failure 400 {object} model.Response "Bad Request - Invalid input data"
 // @Failure 500 {object} model.Response "Internal Server Error"
-// @Router /user/register [post]
+// @Router /users/register [post]
 func (ctrl *UserController) FakeRegister(c *gin.Context) {
 	var request model.CreateFakeUserRequest
 

--- a/pkg/router/event_route.go
+++ b/pkg/router/event_route.go
@@ -7,11 +7,11 @@ import (
 )
 
 func RegisterEventRouter(app *bootstrap.Application, controller *controller.EventController) {
-	r := app.Engine.Group("/event")
+	r := app.Engine.Group("/events")
 	authMiddleware := middleware.AuthMiddleware(app.Env.JWT.AccessTokenSecret, app.Cache)
 
 	r.GET("", controller.GetAllEvent)
-	r.GET("/user", authMiddleware, controller.GetUserEvent)
+	r.GET("/users", authMiddleware, controller.GetUserEvent)
 	r.GET("/:id", controller.GetEventByID)
 	r.POST("", controller.SubscribeEvent)
 	r.PUT("/:id", controller.UpdateEvent)

--- a/pkg/router/user_route.go
+++ b/pkg/router/user_route.go
@@ -7,7 +7,7 @@ import (
 )
 
 func RegisterUserRoutes(app *bootstrap.Application, controller *controller.UserController) {
-	r := app.Engine.Group("/user")
+	r := app.Engine.Group("/users")
 	authMiddleware := middleware.AuthMiddleware(app.Env.JWT.AccessTokenSecret, app.Cache)
 
 	r.GET("/profile", authMiddleware, controller.Profile)


### PR DESCRIPTION
# fix : rename routes by Restful API guideline
- `/user` -> `/users`
- `/event` -> `/events`

`/users/{id}`: Represents a collection of users, with the specific user identified by `{id}`.
While `/user/{id}` would represent a single user.